### PR TITLE
"Error: Cannot find module '../modules'" when --ls specified.

### DIFF
--- a/bin/builder.js
+++ b/bin/builder.js
@@ -38,7 +38,7 @@ if (argv.help) {
 }
 
 if (argv.ls) {
-  var comp = require('../modules');
+  var comp = require('../data').modules;
   console.log('Modules:');
   comp.forEach(function(c) {
     console.log(c);


### PR DESCRIPTION
Not sure if I'm missing something, but I was getting the following when I tried to list the current modules:

```
jquery-builder --ls

module.js:340
    throw err;
          ^
Error: Cannot find module '../modules'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (C:\Development\scripting.js\jqbuild\node_modules\jquery-builder\bin\builder.js:41:14)
    at Module._compile (module.js:454:26)
    at Object.Module._extensions..js (module.js:472:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:497:10)
```
