### PR TITLE
Download jquery from raw.github.com

### DIFF
--- a/bin/builder.js
+++ b/bin/builder.js
@@ -64,7 +64,7 @@ if (argv.versions) {
 var exclude = (argv.exclude) ? argv.exclude.split(',') : undefined;
 
 var file = filename(exclude, argv.minify);
-var url = 'https://rawgithub.com/jgallen23/jquery-builder/'+version+'/dist/'+argv.version+'/'+file;
+var url = 'https://raw.github.com/jgallen23/jquery-builder/'+version+'/dist/'+argv.version+'/'+file;
 request.get(url, function(err, response, body) {
   if (err) {
     throw err;


### PR DESCRIPTION
rawgithub.com is down right now and we don't need the content type which seems to be the reason rawgithub.com was created according to this blog post http://wonko.com/post/rawgithub
